### PR TITLE
binding.js throwing error when inputs[widget.name] is undefined

### DIFF
--- a/web/js/common/binding.js
+++ b/web/js/common/binding.js
@@ -187,7 +187,9 @@ app.registerExtension({
 				const r = onAdded?.apply(this, arguments);
 
 				for (const widget of this.widgets || []) {
-					const bindings = inputs[widget.name][1]?.["pysssss.binding"];
+					const widgedInput = inputs[widget.name];
+					if(!widgedInput) continue;
+					const bindings = widgedInput[1]?.["pysssss.binding"];
 					if (!bindings) continue;
 
 					for (const binding of bindings) {


### PR DESCRIPTION
I had some weird issue when creating group nodes. Looks like simple fix, so here is PR for handling the undefined value.

![image](https://github.com/user-attachments/assets/b8ce52f1-26db-497e-b08b-a12333bc7810)
